### PR TITLE
Update import_mdb.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "MDB format",
     "author": "BlueAmulet",
-    "version": (1, 0, 9),
+    "version": (1, 0, 10),
     "blender": (2, 90, 0),
     "location": "File > Import-Export",
     "description": "Import-Export MDB, mesh, UV's, materials and textures",

--- a/import_mdb.py
+++ b/import_mdb.py
@@ -430,7 +430,7 @@ def load(operator, context, filepath='', **kwargs):
                     textures[filename] = image
                     # Why is Straight being treated as Premultiplied by cycles?
                     image.alpha_mode = 'CHANNEL_PACKED'
-                    if 'albedo' not in txr_map and 'diffuse' not in txr_map:
+                    if 'diffuse' not in txr_map:
                         image.colorspace_settings.name = 'Non-Color'
                     if txr_map == 'normal' or txr_map == 'damage_normal':
                         np_pxl = np.empty(len(image.pixels), dtype=np.float32)


### PR DESCRIPTION
Changed the image color space setting sRGB for Albedo import to Non colors, This will change the look of all model's Albedo layer to be more accurate to the in game models.